### PR TITLE
Intial compilation support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:25.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    ninja-build \
+    python3 \
+    python3-pip \
+    python3-venv \
+    git \
+    scons \
+    pkg-config \
+    libx11-dev \
+    libxcursor-dev \
+    libxinerama-dev \
+    libgl1-mesa-dev \
+    libglu1-mesa-dev \
+    libasound2-dev \
+    libpulse-dev \
+    libudev-dev \
+    libxi-dev \
+    libxrandr-dev \
+    libxss-dev \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+USER ubuntu
+WORKDIR /workspaces
+
+# Create and activate a Python virtual environment, then install Python dependencies there
+ENV VIRTUAL_ENV=/workspaces/.venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN python3 -m venv $VIRTUAL_ENV \
+    && $VIRTUAL_ENV/bin/pip install --upgrade pip \
+    && $VIRTUAL_ENV/bin/pip install -r /tmp/pyproject.toml || true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+    "name": "Godot Slang DevContainer",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "configureZshAsDefaultShell": true,
+            // "username": ""
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "terminal.integrated.shell.linux": "/bin/bash"
+            },
+            "extensions": [
+                "ms-vscode.cpptools",
+                "ms-python.python",
+                "ms-vscode.cmake-tools",
+                "ms-vscode.makefile-tools",
+                "neikeq.godot-csharp-vscode",
+                "geequlim.godot-tools",
+                "shader-slang.slang-language-extension"
+            ]
+        }
+    },
+    // "postCreateCommand": "pip3 install --user -r godot-cpp/pyproject.toml || true",
+    "remoteUser": "ubuntu",
+    // "workspaceFolder": "/workspaces"
+}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,62 @@
+# GitHub Actions Workflows
+
+This directory contains GitHub Actions workflows for the Godot Slang project.
+
+## Workflows
+
+### `release.yml` - Release Build
+**Triggers:** GitHub releases, Manual dispatch
+
+This workflow creates production-ready releases:
+
+- Builds only the release version for Linux
+- Uses Ubuntu 25.04 container (matching the dev container)
+- Builds Slang generators and static library
+- Builds godot-cpp dependency
+- Builds the godot-slang extension
+- Packages the complete demo folder as a ready-to-use Godot project
+- Creates a zip file for easy distribution
+- Automatically uploads to GitHub releases (when triggered by a release)
+
+Todo: move built libraries to addons/godot-slang
+
+**Artifacts:**
+- `godot-slang-demo-linux` - Complete demo project package
+- `godot-slang-demo.zip` - Zipped demo project for distribution
+
+## Build Process
+
+The workflow follows this process:
+
+1. **Environment Setup**: Install build dependencies matching the dev container
+2. **Slang Build**: 
+   - Build Slang generators using CMake presets
+   - Configure and build Slang static library
+3. **godot-cpp Build**: Build the Godot C++ bindings (release mode)
+4. **Extension Build**: Build the godot-slang extension using SCons (release mode)
+5. **Package**: Package the complete demo folder with built binaries
+
+## Usage
+
+### For Releases
+1. Create a GitHub release with a tag
+2. The release workflow will automatically build and attach the addon package
+3. Or manually trigger the release workflow from the Actions tab
+
+### For Development
+To test builds during development, manually trigger the release workflow from the Actions tab.
+
+## Requirements
+
+The workflow requires no special setup - it uses the same dependencies as the dev container and should work out of the box on any repository with this project structure.
+
+## Platform Support
+
+Currently only Linux x86_64 is supported. To add more platforms, update the SCons platform parameters in the workflow.
+
+## Troubleshooting
+
+- Check the workflow logs in the Actions tab
+- Manually trigger the release workflow to test builds
+- Verify submodules are properly initialized
+- Check that all dependencies are available in the container

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ jobs:
       options: --user root
     
     steps:
+      - name: Install Git (required for checkout with submodules)
+        run: |
+          apt-get update
+          apt-get install -y git ca-certificates
+      
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -38,7 +43,6 @@ jobs:
             python3 \
             python3-pip \
             python3-venv \
-            git \
             scons \
             pkg-config \
             libx11-dev \
@@ -53,7 +57,6 @@ jobs:
             libxrandr-dev \
             libxss-dev \
             libssl-dev \
-            ca-certificates \
             zip
       
       - name: Set up Python virtual environment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,124 @@
+name: Release Build
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag for the release'
+        required: false
+        default: 'latest'
+
+env:
+  LANG: en_US.UTF-8
+  LC_ALL: en_US.UTF-8
+
+jobs:
+  build-release:
+    name: 🚀 Build Release
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:25.04
+      options: --user root
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      
+      - name: Set up build environment
+        run: |
+          apt-get update
+          apt-get install -y \
+            build-essential \
+            cmake \
+            ninja-build \
+            python3 \
+            python3-pip \
+            python3-venv \
+            git \
+            scons \
+            pkg-config \
+            libx11-dev \
+            libxcursor-dev \
+            libxinerama-dev \
+            libgl1-mesa-dev \
+            libglu1-mesa-dev \
+            libasound2-dev \
+            libpulse-dev \
+            libudev-dev \
+            libxi-dev \
+            libxrandr-dev \
+            libxss-dev \
+            libssl-dev \
+            ca-certificates \
+            zip
+      
+      - name: Set up Python virtual environment
+        run: |
+          python3 -m venv /opt/venv
+          echo "/opt/venv/bin" >> $GITHUB_PATH
+          /opt/venv/bin/pip install --upgrade pip
+      
+      - name: Install Python dependencies
+        run: |
+          if [ -f godot-cpp/pyproject.toml ]; then
+            /opt/venv/bin/pip install -r godot-cpp/pyproject.toml || true
+          fi
+      
+      - name: Build Slang generators
+        run: |
+          cd slang
+          cmake --workflow --preset generators --fresh
+          mkdir -p ../build-platform-generators
+          cmake --install build --config Release --prefix ../build-platform-generators --component generators
+      
+      - name: Configure and build Slang
+        run: |
+          cd slang
+          cmake \
+            --preset default \
+            --fresh \
+            -DSLANG_LIB_TYPE=STATIC \
+            -DSLANG_GENERATORS_PATH=../build-platform-generators/bin
+          cmake --build --preset release --target slang
+      
+      - name: Build godot-slang extension (release)
+        run: |
+          scons target=template_release
+      
+      - name: Create demo package
+        run: |
+          # Copy license to demo folder if it exists
+          if [ -f LICENSE ]; then
+            cp LICENSE demo/
+          fi
+          
+          # Create zip package of the demo folder
+          zip -r godot-slang-demo.zip demo/
+          
+          # List package contents
+          echo "Package contents:"
+          unzip -l godot-slang-demo.zip
+      
+      - name: Upload demo package
+        uses: actions/upload-artifact@v4
+        with:
+          name: godot-slang-demo-linux
+          path: |
+            godot-slang-demo.zip
+            demo/
+          retention-days: 90
+      
+      - name: Upload to release (if this is a release event)
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./godot-slang-demo.zip
+          asset_name: godot-slang-demo.zip
+          asset_content_type: application/zip

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build
 build-platform-generators
 .sconsign.dblite
 extension_api.json
+__pycache__/
 
 # Compiled Object files
 *.slo
@@ -16,3 +17,12 @@ extension_api.json
 *.o
 *.obj
 *.os
+
+# Generated files to ignore
+demo/.godot
+demo/bin
+demo/shader.glsl
+demo/shader.glsl.import
+
+# Keep documentation
+src/doc_data_godot_slang.gen.h

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Integration of the Slang shader language into Godot.
 
 **WORK IN PROGRESS!**
 
-## How to build for macOS
+## How to build for Linux
 
-1. Clone repository recursively
-2. Build godot-cpp according to docs
-3. Build Slang like this:
+1. Build Slang like this:
 ```
 # Build the generators
+# You need a recent CMake verstion
+cd slang
 cmake --workflow --preset generators --fresh
 mkdir build-platform-generators
 cmake --install build --config Release --prefix ../build-platform-generators --component generators
@@ -21,7 +21,6 @@ cmake \
   --fresh \
   -DSLANG_LIB_TYPE=STATIC \
   -DSLANG_GENERATORS_PATH=../build-platform-generators/bin \
-  -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
   -Dwhatever-other-necessary-options-for-your-cross-build \
   # for example \
   -DCMAKE_C_COMPILER=my-arch-gcc \
@@ -30,3 +29,15 @@ cmake \
 # Build slang library
 cmake --build --preset release --target slang
 ```
+
+2. Build the project
+```
+scons target=template_release
+```
+
+# Acknowledgments
+
+The Slang compilation examples in this project are based on the official [Slang repository examples](https://github.com/shader-slang/slang/tree/master/examples), particularly:
+- [hello-world](https://github.com/shader-slang/slang/blob/master/examples/hello-world/main.cpp) for the basic compilation patterns
+
+The documentation generation system (`editor_builders.py`) is adapted from the [threen project](https://github.com/deralmas/threen/tree/doc) by deralmas, which demonstrates embedded XML documentation in Godot GDExtensions.

--- a/SConstruct
+++ b/SConstruct
@@ -4,7 +4,7 @@ import sys
 
 LIB_NAME = "libgodot-slang" # Must have "lib" as prefix
 
-BUILD_PATH = "build/addons/godot-slang"
+BUILD_PATH = "demo"
 
 SLANG_DEBUG_INCLUDE_PATH = "slang/build/RelWithDebInfo/include/"
 SLANG_DEBUG_LIB_PATHS = [
@@ -37,12 +37,22 @@ env = SConscript("godot-cpp/SConstruct")
 env.Append(CPPPATH=["src/"])
 sources = Glob("src/*.cpp")
 
+import editor_builders
+
+docs_xml = []
+docs_xml += Glob("src/doc_classes/*.xml")
+docs_xml = sorted(docs_xml)
+docs_header = "src/doc_data_godot_slang.gen.h"
+env.Command(docs_header, docs_xml, env.Action(editor_builders.make_doc_header, "Generating documentation header."))
+
 if env["target"] == "template_release":
     env.Append(CPPPATH=SLANG_RELEASE_INCLUDE_PATH)
     env.Append(LIBPATH=SLANG_RELEASE_LIB_PATHS)
 else:
-    env.Append(CPPPATH=SLANG_DEBUG_INCLUDE_PATH)
-    env.Append(LIBPATH=SLANG_DEBUG_LIB_PATHS)
+    env.Append(CPPPATH=SLANG_RELEASE_INCLUDE_PATH)
+    env.Append(LIBPATH=SLANG_RELEASE_LIB_PATHS)
+    # env.Append(CPPPATH=SLANG_DEBUG_INCLUDE_PATH)
+    # env.Append(LIBPATH=SLANG_DEBUG_LIB_PATHS)
 env.Append(LIBS=SLANG_LIBS)
 
 file_name = LIB_NAME + "." + env["target"][9:] # Trim "template_"

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,48 @@
+# Godot Slang Extension Demo
+
+This is a demo project showcasing the Godot Slang extension, which integrates the Slang shader language into Godot.
+
+## About
+
+The Godot Slang extension allows you to write and compile Slang shaders directly in your Godot projects, providing advanced shader capabilities and cross-platform shader compilation.
+
+## Installation
+
+1. Copy this entire `demo` folder to your Godot project directory
+2. The extension should be automatically detected by Godot
+3. Open the project in Godot and explore the example scenes and scripts
+
+## Contents
+
+- `bin/` - Contains the compiled GDExtension binaries
+- `scenes/` - Example scenes demonstrating Slang shader usage
+- `Scripts/` - Example scripts showing how to work with Slang shaders
+- `project.godot` - Godot project file
+- `*.slang` - Example Slang shader files
+
+## Project Repository
+
+For more information, documentation, and the latest updates, visit the main project repository:
+
+**https://github.com/celestialsim/godot-slang**
+
+## Platform Support
+
+This demo includes binaries for:
+- Linux x86_64
+
+## License
+
+See the LICENSE file in the main repository for licensing information.
+
+## Getting Started
+
+1. Open this project in Godot
+2. Navigate to the `scenes/` folder and open `Main.tscn`
+3. Run the scene to compile the Slang shader into a glsl file
+4. Examine the `.slang` files to understand the shader syntax
+5. Check the scripts in `Scripts/` to see how to load and use Slang shaders from code
+
+## Support
+
+For issues, questions, or contributions, please visit the GitHub repository linked above.

--- a/demo/Scripts/test.gd
+++ b/demo/Scripts/test.gd
@@ -1,0 +1,6 @@
+extends Node
+
+func _ready():
+	# Spawn a TestCompile node and call its function
+	var tc = TestCompile.new()
+	tc.compile_slang_to_glsl("shader")

--- a/demo/Scripts/test.gd.uid
+++ b/demo/Scripts/test.gd.uid
@@ -1,0 +1,1 @@
+uid://dxrgmbrwwwj8h

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -1,0 +1,19 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="GodotSlangDemo"
+run/main_scene="uid://b3mtpi2f67w6n"
+config/features=PackedStringArray("4.4")
+
+[dotnet]
+
+project/assembly_name="GodotSlangDemo"

--- a/demo/scenes/Main.tscn
+++ b/demo/scenes/Main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://b3mtpi2f67w6n"]
+
+[ext_resource type="Script" uid="uid://dxrgmbrwwwj8h" path="res://Scripts/test.gd" id="1_elqb8"]
+
+[node name="TestScene" type="Node3D"]
+script = ExtResource("1_elqb8")

--- a/demo/shader.slang
+++ b/demo/shader.slang
@@ -1,0 +1,11 @@
+StructuredBuffer<float> buffer0;
+StructuredBuffer<float> buffer1;
+RWStructuredBuffer<float> result;
+
+[shader("compute")]
+[numthreads(1,1,1)]
+void computeMain(uint3 threadId : SV_DispatchThreadID)
+{
+    uint index = threadId.x;
+    result[index] = buffer0[index] + buffer1[index];
+}

--- a/editor_builders.py
+++ b/editor_builders.py
@@ -1,0 +1,38 @@
+def make_doc_header(target, source, env):
+    #import zlib
+
+    dst = str(target[0])
+    g = open(dst, "w", encoding="utf-8")
+    buf = ""
+    docbegin = ""
+    docend = ""
+    for src in source:
+        src = str(src)
+        if not src.endswith(".xml"):
+            continue
+        with open(src, "r", encoding="utf-8") as f:
+            content = f.read()
+        buf += content
+
+    buf = (docbegin + buf + docend).encode("utf-8")
+    #decomp_size = len(buf)
+
+    # Use maximum zlib compression level to further reduce file size
+    # (at the cost of initial build times).
+    #buf = zlib.compress(buf, zlib.Z_BEST_COMPRESSION)
+
+    g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
+    g.write("#ifndef _DOC_DATA_RAW_H\n")
+    g.write("#define _DOC_DATA_RAW_H\n")
+    #g.write("static const int _doc_data_compressed_size = " + str(len(buf)) + ";\n")
+    #g.write("static const int _doc_data_uncompressed_size = " + str(decomp_size) + ";\n")
+    #g.write("static const unsigned char _doc_data_compressed[] = {\n")
+    g.write("static const int _doc_data_size = " + str(len(buf)) + ";\n")
+    g.write("static const char _doc_data[] = {\n")
+    for i in range(len(buf)):
+        g.write("\t" + str(buf[i]) + ",\n")
+    g.write("};\n")
+
+    g.write("#endif")
+
+    g.close()

--- a/src/doc_classes/TestCompile.xml
+++ b/src/doc_classes/TestCompile.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="TestCompile" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Compiles Slang shader files to GLSL format using the Slang compilation API.
+	</brief_description>
+	<description>
+		TestCompile provides functionality to cross-compile shader code from Slang to GLSL format. 
+		The implementation follows patterns from the official Slang hello-world example for robust compilation.
+		
+		This class integrates the Slang compiler into Godot, allowing developers to write shaders in 
+		the Slang language and automatically convert them to GLSL for use in Godot projects.
+	</description>
+	<tutorials>
+		<link title="Slang Documentation">https://shader-slang.com/slang/</link>
+		<link title="Official Slang Examples">https://github.com/shader-slang/slang/tree/master/examples</link>
+	</tutorials>
+	<methods>
+		<method name="compile_slang_to_glsl">
+			<return type="void" />
+			<param index="0" name="filename" type="String" />
+			<description>
+				Compiles a Slang shader file to GLSL format with automatic timestamp generation.
+				
+				The function looks for [param filename].slang and generates [param filename].glsl with:
+				- Generation timestamp and source information
+				- Godot-compatible #[compute] annotations  
+				- OpenGL 4.6 GLSL target specification
+				
+				Requirements:
+				- Input file must have a compute shader entry point named "computeMain"
+				- Entry point must be tagged with [shader("compute")] attribute
+				- Slang compiler must be properly initialized and linked
+				
+				Process:
+				1. Creates a global Slang session (compiler instance)
+				2. Sets up a local session with GLSL target configuration
+				3. Loads the Slang module from the source file
+				4. Finds the compute shader entry point ("computeMain") 
+				5. Composes the module and entry point into a program
+				6. Generates the target GLSL code
+				7. Saves the result with metadata headers
+			</description>
+		</method>
+		<method name="test_compile">
+			<return type="void" />
+			<description>
+				Simple test method that prints a compilation test message.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,44 +1,58 @@
 #include "register_types.h"
-
-// #include "gdexample.h"
+#include "test_compile.h"
+#include "doc_data_godot_slang.gen.h"
 
 #include <gdextension_interface.h>
+#include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/core/defs.hpp>
 #include <godot_cpp/godot.hpp>
 
 using namespace godot;
 
-void initialize_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
+void initialize_module(ModuleInitializationLevel p_level)
+{
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE)
+	{
+		ClassDB::register_class<TestCompile>();
 	}
 
-	// GDREGISTER_CLASS(GDExample);
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR)
+	{
+		typedef void (*GDExtensionInterfaceEditorHelpLoadXMLFromUTF8CharsAndLen)(const char *p_data, int p_size);
+		GDExtensionInterfaceEditorHelpLoadXMLFromUTF8CharsAndLen editor_help_load_xml_from_utf8_chars_and_len =
+			(GDExtensionInterfaceEditorHelpLoadXMLFromUTF8CharsAndLen)internal::gdextension_interface_get_proc_address("editor_help_load_xml_from_utf8_chars_and_len");
+
+		if (editor_help_load_xml_from_utf8_chars_and_len)
+		{
+			editor_help_load_xml_from_utf8_chars_and_len(_doc_data, _doc_data_size);
+		}
+	}
 }
 
-void uninitialize_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+void uninitialize_module(ModuleInitializationLevel p_level)
+{
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE)
+	{
 		return;
 	}
 }
 
-extern "C" {
-// Initialization.
-GDExtensionBool GDE_EXPORT godot_slang_init(
-    GDExtensionInterfaceGetProcAddress p_get_proc_address,
-    const GDExtensionClassLibraryPtr p_library,
-    GDExtensionInitialization *r_initialization
-) {
-	godot::GDExtensionBinding::InitObject init_obj(
-        p_get_proc_address, p_library, r_initialization
-    );
+extern "C"
+{
+	// Initialization.
+	GDExtensionBool GDE_EXPORT godot_slang_init(
+		GDExtensionInterfaceGetProcAddress p_get_proc_address,
+		const GDExtensionClassLibraryPtr p_library,
+		GDExtensionInitialization *r_initialization)
+	{
+		godot::GDExtensionBinding::InitObject init_obj(
+			p_get_proc_address, p_library, r_initialization);
 
-	init_obj.register_initializer(initialize_module);
-	init_obj.register_terminator(uninitialize_module);
-	init_obj.set_minimum_library_initialization_level(
-        MODULE_INITIALIZATION_LEVEL_SCENE
-    );
+		init_obj.register_initializer(initialize_module);
+		init_obj.register_terminator(uninitialize_module);
+		init_obj.set_minimum_library_initialization_level(
+			MODULE_INITIALIZATION_LEVEL_SCENE);
 
-	return init_obj.init();
-}
+		return init_obj.init();
+	}
 }

--- a/src/test_compile.cpp
+++ b/src/test_compile.cpp
@@ -1,0 +1,165 @@
+#include "test_compile.h"
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/object.hpp>
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/time.hpp>
+#include <godot_cpp/godot.hpp>
+#include <iostream>
+#include <vector>
+#include "slang-com-ptr.h"
+
+using namespace godot;
+using Slang::ComPtr;
+
+void TestCompile::_bind_methods()
+{
+    ClassDB::bind_method(D_METHOD("test_compile"), &TestCompile::test_compile);
+    ClassDB::bind_method(D_METHOD("compile_slang_to_glsl", "filename"), &TestCompile::compile_slang_to_glsl);
+}
+
+void TestCompile::test_compile()
+{
+    UtilityFunctions::print("This is a compilation test that can be invoked from Godot");
+    // compile_slang_to_glsl("shader");
+}
+
+void TestCompile::compile_slang_to_glsl(const String &filename)
+{
+    // Helper function to print diagnostics if any
+    auto diagnoseIfNeeded = [](ComPtr<slang::IBlob> diagnostics)
+    {
+        if (diagnostics && diagnostics->getBufferSize() > 0)
+        {
+            String diagnostic_text = String::utf8(static_cast<const char *>(diagnostics->getBufferPointer()), diagnostics->getBufferSize());
+            UtilityFunctions::print("Slang diagnostics: " + diagnostic_text);
+        }
+    };
+
+    // Create the global session - using ComPtr for proper resource management
+    ComPtr<slang::IGlobalSession> slangGlobalSession;
+    SlangResult result = slang::createGlobalSession(slangGlobalSession.writeRef());
+    if (SLANG_FAILED(result))
+    {
+        UtilityFunctions::print("Failed to create Slang global session");
+        return;
+    }
+
+    // Create a compilation session to generate GLSL code from Slang source
+    slang::SessionDesc sessionDesc = {};
+    slang::TargetDesc targetDesc = {};
+    targetDesc.format = SLANG_GLSL;
+    targetDesc.profile = slangGlobalSession->findProfile("glsl_460");
+    targetDesc.flags = 0;
+
+    sessionDesc.targets = &targetDesc;
+    sessionDesc.targetCount = 1;
+
+    ComPtr<slang::ISession> session;
+    result = slangGlobalSession->createSession(sessionDesc, session.writeRef());
+    if (SLANG_FAILED(result))
+    {
+        UtilityFunctions::print("Failed to create Slang session");
+        return;
+    }
+
+    // Load the Slang module
+    slang::IModule *slangModule = nullptr;
+    {
+        ComPtr<slang::IBlob> diagnosticBlob;
+        String slang_file = filename + String(".slang");
+        slangModule = session->loadModule(slang_file.utf8().get_data(), diagnosticBlob.writeRef());
+        diagnoseIfNeeded(diagnosticBlob);
+        if (!slangModule)
+        {
+            UtilityFunctions::print("Error loading Slang module: " + slang_file);
+            return;
+        }
+    }
+
+    UtilityFunctions::print("Loaded Slang module successfully!");
+
+    // Find the entry point by name (assuming "computeMain" or similar)
+    ComPtr<slang::IEntryPoint> entryPoint;
+    slangModule->findEntryPointByName("computeMain", entryPoint.writeRef());
+    if (!entryPoint)
+    {
+        UtilityFunctions::print("Could not find entry point 'computeMain'. Make sure your shader has [shader(\"compute\")] void computeMain(...)");
+        return;
+    }
+
+    // Create a composite component type from the module and entry point
+    std::vector<slang::IComponentType *> componentTypes;
+    componentTypes.push_back(slangModule);
+    componentTypes.push_back(entryPoint);
+
+    ComPtr<slang::IComponentType> composedProgram;
+    {
+        ComPtr<slang::IBlob> diagnosticsBlob;
+        result = session->createCompositeComponentType(
+            componentTypes.data(),
+            (SlangInt)componentTypes.size(),
+            composedProgram.writeRef(),
+            diagnosticsBlob.writeRef());
+        diagnoseIfNeeded(diagnosticsBlob);
+        if (SLANG_FAILED(result))
+        {
+            UtilityFunctions::print("Failed to compose program");
+            return;
+        }
+    }
+
+    // Generate the target code (GLSL)
+    ComPtr<slang::IBlob> shaderCode;
+    {
+        ComPtr<slang::IBlob> diagnosticsBlob;
+        result = composedProgram->getEntryPointCode(
+            0, // entryPointIndex
+            0, // targetIndex
+            shaderCode.writeRef(),
+            diagnosticsBlob.writeRef());
+        diagnoseIfNeeded(diagnosticsBlob);
+        if (SLANG_FAILED(result))
+        {
+            UtilityFunctions::print("Compilation failed!");
+            return;
+        }
+    }
+
+    String output_message = String("Successfully compiled ") + String::num_int64(shaderCode->getBufferSize()) + String(" bytes of GLSL code.");
+    UtilityFunctions::print(output_message);
+
+    // Save the compiled shader code to a GLSL file
+    String output_filename = filename + String(".glsl");
+    Ref<FileAccess> file = FileAccess::open(output_filename, FileAccess::WRITE);
+    if (file.is_valid())
+    {
+        // Get current date and time
+        Time *time = Time::get_singleton();
+        Dictionary datetime = time->get_datetime_dict_from_system();
+
+        String current_date = String::num_int64(datetime["year"]) + "-" +
+                              String::num_int64(datetime["month"]).pad_zeros(2) + "-" +
+                              String::num_int64(datetime["day"]).pad_zeros(2);
+        String current_time = String::num_int64(datetime["hour"]).pad_zeros(2) + ":" +
+                              String::num_int64(datetime["minute"]).pad_zeros(2) + ":" +
+                              String::num_int64(datetime["second"]).pad_zeros(2);
+
+        // Add generation comment with dynamic date/time and shader type
+        String slang_source = filename + String(".slang");
+        file->store_string("// File generated from godot-slang on " + current_date + " at " + current_time + "\n");
+        file->store_string("// Original source: " + slang_source + "\n");
+        file->store_string("// Shader type: GLSL Compute Shader (OpenGL 4.6)\n");
+        file->store_string("#[compute]\n\n");
+
+        // Convert the shader code to a string since it's now GLSL text
+        String shader_text = String::utf8(static_cast<const char *>(shaderCode->getBufferPointer()), shaderCode->getBufferSize());
+        file->store_string(shader_text);
+        file->close();
+        UtilityFunctions::print("Shader saved to: " + output_filename);
+    }
+    else
+    {
+        UtilityFunctions::print("Failed to save shader to: " + output_filename);
+    }
+}

--- a/src/test_compile.h
+++ b/src/test_compile.h
@@ -1,0 +1,52 @@
+#ifndef GODOT_SLANG_TEST_COMPILE_H
+#define GODOT_SLANG_TEST_COMPILE_H
+
+#include <godot_cpp/classes/object.hpp>
+#include <slang.h>
+
+using namespace godot;
+
+class TestCompile : public Object
+{
+    GDCLASS(TestCompile, Object);
+
+protected:
+    static void _bind_methods();
+
+public:
+    void test_compile();
+
+    /**
+     * @brief Compiles a Slang shader file to GLSL format using the Slang compilation API
+     *
+     * This function demonstrates how to use the Slang compiler API to cross-compile
+     * shader code from Slang to GLSL. The implementation follows the patterns from
+     * the createComputePipelineFromShader function in the official Slang hello-world example:
+     * https://github.com/shader-slang/slang/blob/master/examples/hello-world/main.cpp
+     *
+     * @param filename The base filename (without extension) of the Slang shader to compile.
+     *                 The function will look for filename.slang and generate filename.glsl
+     *
+     * @details Process overview:
+     * 1. Create a global Slang session (compiler instance)
+     * 2. Set up a local session with GLSL target configuration
+     * 3. Load the Slang module from the source file
+     * 4. Find the compute shader entry point ("computeMain")
+     * 5. Compose the module and entry point into a program
+     * 6. Generate the target GLSL code
+     * 7. Save the result with metadata headers
+     *
+     * @note Requirements:
+     * - Input file must have a compute shader entry point named "computeMain"
+     * - Entry point must be tagged with [shader("compute")] attribute
+     * - Slang compiler must be properly initialized and linked
+     *
+     * @note Output:
+     * - Generates a .glsl file with Godot-compatible annotations
+     * - Includes generation timestamp and source information
+     * - Targets OpenGL 4.6 GLSL specification
+     */
+    void compile_slang_to_glsl(const String &filename);
+};
+
+#endif // GODOT_SLANG_TEST_COMPILE_H


### PR DESCRIPTION
The PR adds initial GLSL compilation support, CI and documentation.

There are several limiations:
- Only compute shaders are supported
- Only GLSL output files are supported, no SPIR-V
- The CI needs to be manually triggered and produces artifacts only for Linux
- There is no editor plugin yet so the compilation runs after starting the game instead of in the editor on file change or import
- Loose intergration with Godot. It would be great to support a better integration so that .slang files can be as simple to create and edit as GLSL files. 